### PR TITLE
HBP PROV  contributor lab and resources

### DIFF
--- a/neuroinformatics/hbp_prov/hbp-prov-schema-v3.0.json
+++ b/neuroinformatics/hbp_prov/hbp-prov-schema-v3.0.json
@@ -104,6 +104,14 @@
                         "description": "Checksum of the file. Not applicable for databases.",
                         "$ref": "#/definitions/checksum"
                     },
+                    "size": {
+                        "description": "The size of the file in bytes.",
+                        "type": "long"
+                    },
+                    "original_filename": {
+                        "description": "The name of the file at the time of data submission.",
+                        "type": "string"
+                    },
                     "comment": {
                         "type": "string"
                     },
@@ -217,6 +225,11 @@
                                 "type": "string"
                             },
                             "organisation_ref": {
+                                "description": "The organisation the contributor is affiliated to.",
+                                "type": "string"
+                            },
+                            "laboratory": {
+                                "description": "The laboratory as a sub-entity of the organisation to further specify the contributor's affiliation.",
                                 "type": "string"
                             },
                             "email": {

--- a/neuroinformatics/hbp_prov/hbp-prov-schema-v3.0.json
+++ b/neuroinformatics/hbp_prov/hbp-prov-schema-v3.0.json
@@ -496,9 +496,11 @@
                     },
                     "representations": {
                         "type": "array",
+                        "description": "Array of resources' uuid as the physical representations of the dataset.",
                         "minItems": 1,
                         "items": {
                             "type": "string",
+                            "description": "A resource uuid. Must be described in the same registration file.",
                             "format": "uuid"
                         }
                     },

--- a/neuroinformatics/hbp_prov/hbp-prov-schema-v3.0.json
+++ b/neuroinformatics/hbp_prov/hbp-prov-schema-v3.0.json
@@ -106,7 +106,7 @@
                     },
                     "size": {
                         "description": "The size of the file in bytes.",
-                        "type": "long"
+                        "type": "integer"
                     },
                     "original_filename": {
                         "description": "The name of the file at the time of data submission.",

--- a/neuroinformatics/hbp_prov/hbp-prov-schema-v3.0.json
+++ b/neuroinformatics/hbp_prov/hbp-prov-schema-v3.0.json
@@ -169,14 +169,19 @@
                             "type": "object",
                             "required": [
                                 "agent_ref",
-                                "role"
+                                "roles"
                             ],
                             "properties": {
                                 "agent_ref": {
                                     "type": "string"
                                 },
-                                "role": {
-                                    "$ref": "#/definitions/onto_term"
+                                "roles": {
+                                    "description": "An array of role the contributor took during the generation of the dataset.",
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "$ref": "#/definitions/onto_term"
+                                    }
                                 }
                             },
                             "additionalProperties": false

--- a/neuroinformatics/hbp_prov/tests/hbp-prov-example-full.json
+++ b/neuroinformatics/hbp_prov/tests/hbp-prov-example-full.json
@@ -1,20 +1,20 @@
 {
-    "schema_version": "3.0-RC3",
+    "schema_version": "3.0-RC4",
     "activities": [
         {
             "agents": [
                 {
-                    "role": {
+                    "roles": [{
                         "uri": "HBP_ROLE:0000030",
                         "name": "slicer"
-                    },
+                    }],
                     "agent_ref": "1"
                 },
                 {
-                    "role": {
+                    "roles": [{
                         "uri": "HBP_ROLE:0000020",
                         "name": "extraction of tissue"
-                    },
+                    }],
                     "agent_ref": "0"
                 }
             ],
@@ -38,10 +38,10 @@
         {
             "agents": [
                 {
-                    "role": {
+                    "roles": [{
                         "uri": "HBP_ROLE:0000018",
                         "name": "processing of biological sample"
-                    },
+                    }],
                     "agent_ref": "0"
                 }
             ],
@@ -58,17 +58,17 @@
         {
             "agents": [
                 {
-                    "role": {
+                    "roles": [{
                         "uri": "HBP_ROLE:0000026",
                         "name": "analysis of data"
-                    },
+                    }],
                     "agent_ref": "0"
                 },
                 {
-                    "role": {
+                    "roles": [{
                         "uri": "HBP_ROLE:0000032",
                         "name": "reconstructor"
-                    },
+                    }],
                     "agent_ref": "23"
                 }
             ],
@@ -85,10 +85,10 @@
         {
             "agents": [
                 {
-                    "role": {
+                    "roles": [{
                         "uri": "HBP_ROLE:0000030",
                         "name": "slicer"
-                    },
+                    }],
                     "agent_ref": "1"
                 }
             ],
@@ -159,7 +159,7 @@
                     "name": "morphological single cell model"
                 }
             ],
-            "comment": "annotated photo of emslice12",
+            "description": "annotated photo of emslice12",
             "activity_ref": "3d5c20b9-f54c-4e85-97b8-fcf4e178d5d3",
             "id": "119b832f-502c-4749-9827-2ac147744c9b",
             "name": "em-slice-photo12",
@@ -180,7 +180,7 @@
                     "name": "morphological single cell model"
                 }
             ],
-            "comment": "photo of emslice12",
+            "description": "photo of emslice12",
             "activity_ref": "b1d8335b-7153-4e5a-bb99-ffcde998053c",
             "id": "9c6d3c73-1c5d-45df-a27f-ae45fd6be49f",
             "name": "em-slice-photo12",
@@ -298,6 +298,7 @@
     ],
     "classifications": [
         {
+            "classified_entity_ref":"119b832f-502c-4749-9827-2ac147744c9b",
             "assigned_class": {
                 "uri": "http://hbp.org/some_class"
             },

--- a/neuroinformatics/hbp_prov/tests/hbp-prov-example-full.json
+++ b/neuroinformatics/hbp_prov/tests/hbp-prov-example-full.json
@@ -115,6 +115,8 @@
             {
                 "id": "0",
                 "name": "Iurii Katkov",
+                "organisation_ref": "http://epfl.ch",
+                "laboratory": "Blue Brain Project",
                 "email": "iurii.katkov@example.com"
             }
         ],
@@ -202,7 +204,6 @@
     },
     "resources": [
         {
-
             "addresses": [
                 {
                     "uri": "smb://mit.edu/repo/em-stscks32.h3",
@@ -214,6 +215,8 @@
                 }
             ],
             "comment": "h3 representation",
+            "original_filename": "em-stscks32.h3",
+            "size": 23978432987,
             "id": "0a1a6a2f-da31-4fae-83d8-9af458274458",
             "mime_type": {
                 "code": "HBP_FT:0000003",

--- a/neuroinformatics/hbp_prov/tests/hbp-prov-example-min.json
+++ b/neuroinformatics/hbp_prov/tests/hbp-prov-example-min.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "3.0-RC3",
+  "schema_version": "3.0-RC4",
   "registration": {
     "id": "12345678-1234-5678-1234-567812345678",
     "submission_date": "1999",
@@ -26,10 +26,15 @@
       "end_date":"1999-12-22",
       "agents":[{
         "agent_ref":"yuryid",
-        "role": {"uri": "http://ontolorole.com/role1"}
+        "roles": [{"uri": "http://ontolorole.com/role1"}]
       }],
       "source_entities": ["12345678-1234-5678-1234-567812345678"]
     }
   ],
-  "agents": {}
+  "agents": {
+    "organisations":[
+      {"id":"EPFL", "name":"EPFL"},
+      {"id":"LNMC", "name":"LNMC"}
+    ]
+  }
 }


### PR DESCRIPTION
Summary of the upcoming changes in HBP-PROV 3.0-RC4:
- Add /resources.size (in bytes, optional field)
- Add /resources.original_filename (optional field)
- Add /agents.contributors.laboratory (optional field)
- Made /agents.contributors.role an array

Note: resource’s size and filename are needed to enable the orchestrator to communicate uploaded files to the UI.
