### PR TITLE
Agreement's timestamp should be an integer.

### DIFF
--- a/neuroinformatics/single_activity_metadata/single-activity-metadata-schema-1.0.json
+++ b/neuroinformatics/single_activity_metadata/single-activity-metadata-schema-1.0.json
@@ -4,6 +4,7 @@
     "version": "1.0-RC4",
     "type": "object",
     "required": [
+        "schema_version",
         "registration",
         "specimen",
         "dataset"
@@ -32,7 +33,8 @@
                     "properties": {
                         "timestamp": {
                             "description": "Time by which the user agreed with the terms and conditions in the epoch format in milliseconds",
-                            "type": "number"
+                            "type": "integer",
+                            "maximum": 9223372036854775807
                         },
                         "version": {
                             "description": "Version of terms and conditions user agreed with.",


### PR DESCRIPTION
The conversion to Java POJO now correctly generates a Long instead of a Double.
