### PR TITLE
Update the `release` enum: `HBP` is now `hbp_only`.

### DIFF
--- a/neuroinformatics/hbp_prov/CHANGELOG
+++ b/neuroinformatics/hbp_prov/CHANGELOG
@@ -3,7 +3,7 @@
 * Added the field /agents.contributors.affiliations field which groups former /agents.contributors.organisation_ref (required) and /agents.contributors.laboratory fields
   All contributor's affiliations are now grouped in one array /agents.contributors.affiliations
 * Added the field /activities.protocol.designer (string) to keep the information about the lab or person which designed the protocol.
-
+* Updated the `release` enum: `HBP` is now `hbp_only`.
 
 ## [3.0-RC6] 2016-03-03 Yuri Katkov / Samuel Kerrien /  Lomig Mégard / Mohameth François Sy
 ### Added fields

--- a/neuroinformatics/hbp_prov/hbp-prov-schema-v3.0.json
+++ b/neuroinformatics/hbp_prov/hbp-prov-schema-v3.0.json
@@ -62,7 +62,7 @@
                 "release": {
                     "enum": [
                         "private",
-                        "HBP",
+                        "hbp_only",
                         "public"
                     ]
                 }


### PR DESCRIPTION
from @cathzwah request.
